### PR TITLE
Update image_build.yml to include semver as image tag

### DIFF
--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -4,20 +4,32 @@ on:
       - published
 
 name: Docker image publish
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out release source
+        uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.release.tag_name }}
           submodules: true
-      - uses: elgohr/Publish-Docker-Github-Action@v5
-        env:
-          VERSION: ${{ github.ref }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          name: "tudelft3d/cjval"
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          dockerfile: docker/Dockerfile
-          tag_semver: false
-          buildargs: VERSION
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            tudelft3d/cjval:latest
+            tudelft3d/cjval:${{ github.event.release.tag_name }}
+          build-args: |
+            VERSION=${{ github.event.release.tag_name }}


### PR DESCRIPTION
The current image_build workflow only pushes a docker image with a tag `latest` and does not create an image with the version eg. `0.9.0`. This is fix for pushing both `latest` and `<version>` as tags to docker hub.